### PR TITLE
Honor QGIS's snap settings

### DIFF
--- a/qad_getpoint.py
+++ b/qad_getpoint.py
@@ -116,7 +116,6 @@ class QadGetPoint(QgsMapTool):
 
       self.__QadSnapper = QadSnapper()
       self.__QadSnapper.setSnapMode(QadSnapModeEnum.ONE_RESULT) # Viene restituito solo il punto più vicino
-      self.__QadSnapper.setSnapLayers(qad_utils.getVisibleVectorLayers(self.canvas)) # Tutti i layer vettoriali visibili
       self.__QadSnapper.setProgressDistance(QadVariables.get(QadMsg.translate("Environment variables", "OSPROGRDISTANCE")))
       self.setSnapType(QadVariables.get(QadMsg.translate("Environment variables", "OSMODE")))
             

--- a/qad_snapper.py
+++ b/qad_snapper.py
@@ -115,6 +115,8 @@ class QadSnapper():
                                     # altrimenti nearest vincerebbe sempre
       self.tmpGeometries = [] # lista di geometrie qad non ancora esistenti ma da contare per i punti di osnap (in map coordinates)
 
+      self.setSnapLayersFromQgis() # initialise the layers to be snaped to from QGIS settings
+      qgis.utils.iface.mapCanvas().snappingUtils().configChanged.connect(self.setSnapLayersFromQgis) # update snap layers whenever QGIS snap settings change
 
    #============================================================================
    # SnapType
@@ -227,6 +229,11 @@ class QadSnapper():
       Imposta i layer da considerare nello snapping
       """      
       self.__snapLayers = snapLayers
+   def setSnapLayersFromQgis(self):
+      """
+      Sets the layers to be snapped to from QGIS's settings
+      """
+      self.setSnapLayers(qad_utils.getVisibleVectorLayers(qgis.utils.iface.mapCanvas()))
    def getSnapLayers(self):
       """
       Restituisce la lista dei layer da considerare per lo snapping

--- a/qad_utils.py
+++ b/qad_utils.py
@@ -894,8 +894,16 @@ def getFeatureRequest(fetchAttributes = [], fetchGeometry = True, \
 # getVisibleVectorLayers
 #===============================================================================
 def getVisibleVectorLayers(canvas):
-   # Tutti i layer vettoriali visibili
-   layers = canvas.layers()
+   enabled = canvas.snappingUtils().config().enabled()
+   mode = canvas.snappingUtils().config().mode()
+
+   if enabled and mode == QgsSnappingConfig.ActiveLayer:
+      layers = [qgis.utils.iface.activeLayer()]
+   elif enabled and mode == QgsSnappingConfig.AdvancedConfiguration:
+      layers = list(cfg.layer for cfg in canvas.snappingUtils().layers())
+   else: # mode == QgsSnappingConfig.AllLayers:
+      layers = canvas.layers()
+
    for i in range(len(layers) - 1, -1, -1):
       # se il layer non è vettoriale o non è visibile a questa scala
       if layers[i].type() != QgsMapLayer.VectorLayer or \


### PR DESCRIPTION
This implements #49, making QAD honor QGIS's snap settings (ALL LAYERS, ACTIVE LAYER, ADVANCED).

Note that it doesn't affect snapping types (e.g. start/end points, intersections, etc.), as there's no match between QGIS's snap types and QAD's snap types.

Should we rename `getVisibleVectorLayers(canvas)` to `getSnappableVectorLayers(canvas)` on the whole code base ?

Thanks again for the great plugin !