### PR TITLE
Correcting type checking

### DIFF
--- a/qad_dim.py
+++ b/qad_dim.py
@@ -4643,7 +4643,7 @@ class QadDimStylesClass():
          con due parametri, il primo QgsVectorLayer e il secondo l'id della feature
       """
       # verifico se l'entità appartiene ad uno stile di quotatura
-      if type(layer) == QgsVectorLayer:
+      if isinstance(layer, QgsVectorLayer):
          entity = QadEntity()
          entity.set(layer, fid)
          dimStyle, dimId = self.getDimIdByEntity(entity)
@@ -5980,5 +5980,6 @@ def appendDimEntityIfNotExisting(dimEntityList, dimEntity):
 # ===============================================================================
 #  = variabile globale
 # ===============================================================================
+
 
 QadDimStyles = QadDimStylesClass()                 # lista degli stili di quotatura caricati

--- a/qad_entity.py
+++ b/qad_entity.py
@@ -78,7 +78,7 @@ class QadEntity():
    # ===============================================================================
    def set(self, layer_or_entity, featureId = None):
       self.clear()
-      if type(layer_or_entity) == QgsVectorLayer:
+      if isinstance(layer_or_entity, QgsVectorLayer):
          self.layer = layer_or_entity # il layer non si può copiare
          self.featureId = featureId # copio l'identificativo di feature
       else: # layer è una entità
@@ -488,7 +488,7 @@ class QadLayerEntitySet():
       return self.layer.crs()
 
    def set(self, layer, features = None):
-      if type(layer) == QgsVectorLayer:
+      if isinstance(layer, QgsVectorLayer):
          self.layer = layer # il layer non si può copiare
          self.featureIds = []       
          if features is not None:
@@ -802,7 +802,7 @@ class QadEntitySet():
    def findLayerEntitySet(self, layer):
       if layer is None:
          return None
-      if type(layer) == QgsVectorLayer: # layer
+      if isinstance(layer, QgsVectorLayer): # layer
          return self.findLayerEntitySet(layer.id())     
       elif type(layer) == unicode: # id del layer
          for layerEntitySet in self.layerEntitySetList:
@@ -1174,3 +1174,4 @@ def getSelSet(mode, mQgsMapTool, points = None, \
             
    #QApplication.restoreOverrideCursor()
    return result
+


### PR DESCRIPTION
I suggest correcting type checking, firstly this is a modern approach, and secondly if someone uses inherited classes from QgsVectorLayer, then the check fails, which is not logical.